### PR TITLE
Changes DeployHQ strategy to authenticate with deploy clients

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,33 +1,33 @@
 PATH
   remote: .
   specs:
-    omniauth-atech (1.2.2)
+    omniauth-atech (1.3.0)
       omniauth (~> 1.0)
       omniauth-oauth2 (~> 1.1)
 
 GEM
   remote: http://rubygems.org/
   specs:
-    faraday (0.9.2)
+    faraday (1.0.0)
       multipart-post (>= 1.2, < 3)
-    hashie (3.4.4)
-    jwt (1.5.4)
-    multi_json (1.12.1)
-    multi_xml (0.5.5)
-    multipart-post (2.0.0)
-    oauth2 (1.2.0)
-      faraday (>= 0.8, < 0.10)
-      jwt (~> 1.0)
+    hashie (4.1.0)
+    jwt (2.2.1)
+    multi_json (1.14.1)
+    multi_xml (0.6.0)
+    multipart-post (2.1.1)
+    oauth2 (1.4.4)
+      faraday (>= 0.8, < 2.0)
+      jwt (>= 1.0, < 3.0)
       multi_json (~> 1.3)
       multi_xml (~> 0.5)
       rack (>= 1.2, < 3)
-    omniauth (1.3.1)
-      hashie (>= 1.2, < 4)
-      rack (>= 1.0, < 3)
-    omniauth-oauth2 (1.4.0)
-      oauth2 (~> 1.0)
-      omniauth (~> 1.2)
-    rack (2.0.1)
+    omniauth (1.9.1)
+      hashie (>= 3.4.6)
+      rack (>= 1.6.2, < 3)
+    omniauth-oauth2 (1.6.0)
+      oauth2 (~> 1.1)
+      omniauth (~> 1.9)
+    rack (2.2.2)
 
 PLATFORMS
   ruby
@@ -36,4 +36,4 @@ DEPENDENCIES
   omniauth-atech!
 
 BUNDLED WITH
-   1.12.5
+   1.17.2

--- a/lib/omniauth-atech.rb
+++ b/lib/omniauth-atech.rb
@@ -1,3 +1,4 @@
 require "omniauth-atech/version"
 require 'omniauth/strategies/atech'
 require 'omniauth/strategies/codebase'
+require 'omniauth/strategies/deploy'

--- a/lib/omniauth-atech/version.rb
+++ b/lib/omniauth-atech/version.rb
@@ -1,5 +1,5 @@
 module OmniAuth
   module Atech
-    VERSION = "1.2.2"
+    VERSION = "1.3.0"
   end
 end

--- a/lib/omniauth/strategies/atech.rb
+++ b/lib/omniauth/strategies/atech.rb
@@ -5,10 +5,10 @@ module OmniAuth
     class Atech < OmniAuth::Strategies::OAuth2
 
       # Set the site
-      option :client_options, {:site => 'https://identity.atechmedia.com'}
+      option :client_options, { :site => 'https://identity.atechmedia.com' }
 
       # Always request the 'email_address' when authenticating using Omniauth.
-      option :authorize_params, {:scope => 'email_address'}
+      option :authorize_params, { :scope => 'email_address' }
       option :authorize_options, [:prompt]
 
       # Set the UID
@@ -28,7 +28,7 @@ module OmniAuth
 
       # Provide access to the user's raw info
       extra do
-         {'raw_info' => raw_info}
+        { 'raw_info' => raw_info }
       end
 
       # Set the callback URL
@@ -39,15 +39,15 @@ module OmniAuth
       # Return all the raw information for the user
       def raw_info
         @raw_info ||= begin
-           access_token.options[:mode] = :query
-           access_token.options[:param_name] = 'oauth_token'
-           access_token.get('oauth/api/profile').parsed
+          access_token.options[:mode] = :query
+          access_token.options[:param_name] = 'oauth_token'
+          access_token.get('oauth/api/profile').parsed
         end
       end
 
       # Return the user's first e-mail address
       def email_address
-         raw_info['email_addresses'] && raw_info['email_addresses'].first
+        raw_info['email_addresses'] && raw_info['email_addresses'].first
       end
 
     end

--- a/lib/omniauth/strategies/deploy.rb
+++ b/lib/omniauth/strategies/deploy.rb
@@ -2,11 +2,55 @@ require 'omniauth-oauth2'
 
 module OmniAuth
   module Strategies
-    class Deploy < Atech
+    class Deploy < OmniAuth::Strategies::OAuth2
+      # Each authorization must contain user_profile
+      DEFAULT_SCOPE = 'user_profile'.freeze
 
-      # Request access to the Codebase API
-      option :authorize_params, {:scope => 'deploy'}
+      option :client_options, { site: 'http://deploy.localhost' }
 
+      # Request access to the DeployHQ API
+      option :authorize_options, [:scope, :prompt]
+
+      uid { raw_info['identifier'] }
+
+      info do
+        {
+          'name' => "#{raw_info['first_name']} #{raw_info['last_name']}",
+          'first_name' => raw_info['first_name'],
+          'last_name' => raw_info['last_name'],
+          'email' => raw_info['email_address'],
+          'time_zone' => raw_info['time_zone']
+        }
+      end
+
+      extra do
+        { 'raw_info' => raw_info }
+      end
+
+      # Set the callback URL
+      def callback_url
+        full_host + script_name + callback_path
+      end
+
+      # Return all the raw information for the user
+      def raw_info
+        @raw_info ||= begin
+          access_token.options[:mode] = :query
+          access_token.options[:param_name] = 'oauth_token'
+          access_token.get('oauth/api/profile').parsed
+        end
+      end
+
+      def authorize_params
+        super.tap do |params|
+          options[:authorize_params].each do |option|
+            params[option] = request.params[option.to_s] if request.params[option.to_s]
+          end
+
+          params[:scope] = "#{DEFAULT_SCOPE}, #{params[:scope]}"
+        end
+      end
     end
   end
 end
+

--- a/lib/omniauth/strategies/deploy.rb
+++ b/lib/omniauth/strategies/deploy.rb
@@ -6,7 +6,7 @@ module OmniAuth
       # Each authorization must contain user_profile
       DEFAULT_SCOPE = 'user_profile'.freeze
 
-      option :client_options, { site: 'http://deploy.localhost' }
+      option :client_options, { site: 'https://deployhq.com' }
 
       # Request access to the DeployHQ API
       option :authorize_options, [:scope, :prompt]


### PR DESCRIPTION
This PR moves the deploy omniauth strategy in it's own implementation, all oauth tokens will the authenticated with deploy's clients instead of identity.